### PR TITLE
Remove default <leader>a mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,12 @@ Install
     let g:airlatex_domain="www.sharelatex.com"
     ```
 3. For the login, this plugin uses [`browser_cookie3](https://github.com/borisbabic/browser_cookie3). **Please use Firefox or Chrome to login.** Browser_cookie3 will find the right cookie for the server. :)
-4. Open AirLatex in Vim, by using `<leader>a` or by using the command
-    ```
-    :call AirLatex()
-    ```
+4. Open AirLatex in Vim with `:AirLatex`
 
+Feel free to map AirLatex to a binding of your liking, e.g.:
+```
+nmap <leader>a :AirLatex<CR>
+```
 
 Credits
 -------

--- a/plugin/airlatex.vim
+++ b/plugin/airlatex.vim
@@ -57,7 +57,7 @@ function AirLatex_writeBuffer()
 endfunction
 
 
-nmap <leader>a :call AirLatex()<cr>
+command! -nargs=0 AirLatex :call AirLatex()
 
 " globals
 if !exists("g:airlatex_domain")


### PR DESCRIPTION
Removes default mapping and adds AirLatex `:AirLatex` command such that
calling the actual function is not necessary anymore.

Reason for this is that the `<leader>a` mapping could conflict with existing user bindings.