### PR TITLE
Update default domain to overleaf.com

### DIFF
--- a/plugin/airlatex.vim
+++ b/plugin/airlatex.vim
@@ -61,7 +61,7 @@ command! -nargs=0 AirLatex :call AirLatex()
 
 " globals
 if !exists("g:airlatex_domain")
-    let g:airlatex_domain="www.sharelatex.com"
+    let g:airlatex_domain="www.overleaf.com"
 endif
 
 " vim: set sw=4 sts=4 et fdm=marker:


### PR DESCRIPTION
Since 2017 ShareLaTeX joined Overleaf, so sharelatex.com is not available anymore.