### PR TITLE
Fixed «'NoneType' object is not subscriptable» in sidebar.py

### DIFF
--- a/rplugin/python3/airlatex/sidebar.py
+++ b/rplugin/python3/airlatex/sidebar.py
@@ -185,8 +185,12 @@ class SideBar:
                         self.bufferappend("   owner: "+project['owner']['first_name']+(" "+project['owner']['last_name'] if "last_name" in project["owner"] else ""))
                     if "lastUpdated" in project:
                         self.bufferappend("   last change: "+project['lastUpdated'])
-                    if "lastUpdatedBy" in project:
-                        self.bufferappend("    -> by: "+project['lastUpdatedBy']['first_name']+" "+(" "+project['lastUpdatedBy']['last_name'] if "last_name" in project["lastUpdatedBy"] else ""))
+                    if not (project["lastUpdatedBy"] == None):
+                        self.bufferappend("    -> by: " + 
+                                project['lastUpdatedBy']['first_name'] + 
+                                " " + 
+                                " " + 
+                                project['lastUpdatedBy']['last_name'])
 
         # Info
         self.bufferappend("  ")


### PR DESCRIPTION
As far as I understand, it's not enough to check `if "lastUpdatedBy" in project`, it can be `None`. This commit fixes this by checking it is not `None`, so now I don't get any error messages regarding this.
I think it's important to check another `if`-s if they can have such error too. 