### PR TITLE
feat(buftype): add possibility of saving files locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Variable | Possible Values | Description
 `g:AirLatexLogLevel` | `NOTSET` (default), `DEBUG_GUI`, `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` | Verbosity of logging.
 `g:AirLatexLogFile` | `AirLatex.log` (default)  | Log file name. (The file appears in the folder where vim has been started, but only if the log level is greater than `NOTSET`.)
 `g:AirLatexWebsocketTimeout` | `10` (default)  | Number of seconds to wait before declaring the connection as *stale*. This may happen if the server does not answer a request by AirLatex. Setting to `"none"` disables this feature. However, it can be the case that you will not notice when something is wrong with the connection.
-`g:AirLatexBuftype` | `NOFILE` (default), `NORMAL` | Choose the buffer type between `NORMAL`, which allows writing the buffer to a local file, or `NOFILE`, which does not associate the buffer to a file.
+`g:AirLatexBuftype` | `NOFILE` (default), `NORMAL` | Choose the buffer type between `NORMAL`, which allows writing the buffer to a local file, or `NOFILE`, which does not associate the buffer to a file. If `NORMAL` is chosen, the first time a buffer will be saved, AirLatex will check if the current directory is named after the Overleaf project: if so, it will save the buffer in the current directory, otherwise it will create the project folder, save the buffer within it, and move into the project directory.
 
 
 Troubleshooting

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 AirLatex.vim
 ============
-**Current State**: Work in Progress  
+**Current State**: Work in Progress
 (Please use it right now only for testing purposes.)
 
 <p align="center">
@@ -15,7 +15,7 @@ Features
 - list all projects
 - custom servers
 
-**Not implemented, yet**:  
+**Not implemented, yet**:
 This project is just at its dawn, however I plan to also implement the following features in the future:
 - show colored **cursor positions of other users**
 - send **recompile**-command to the server
@@ -42,7 +42,7 @@ Installation / First Use
     " optional: set server name
     let g:AirLatexDomain="www.overleaf.com"
     ```
-    
+
     Using **Vundle**:
     ```
 	Plugin 'da-h/AirLatex.vim'
@@ -53,12 +53,12 @@ Installation / First Use
     let g:AirLatexDomain="www.overleaf.com"
     ```
     After installation using `:PluginInstall` run `:UpdateRemotePlugins` to register the python plugin.
-3. For the login, this plugin uses [keyring](https://pypi.org/project/keyring/) to store credentials by default.  
+3. For the login, this plugin uses [keyring](https://pypi.org/project/keyring/) to store credentials by default.
     On your first login, AirLatex will ask for your password. The credentials will be saved in your keyring. AirLatex does **not** manage credentials for security reasons.
 
-    **If your overleaf/sharelatex instance uses a more complicated login process, set your username to "cookies"**.  
-    In that case, AirLatex will ask you for the session cookies (that unfortunately needs to be lookuped-up by hand in your browser) and paste it into the promt.  
-    Alternatively, assuming your session cookie is YOURSESSIONCOOKIE, you can circumvent the login prompt by setting the username to "cookies:YOURSESSIONCOOKIE".  
+    **If your overleaf/sharelatex instance uses a more complicated login process, set your username to "cookies"**.
+    In that case, AirLatex will ask you for the session cookies (that unfortunately needs to be lookuped-up by hand in your browser) and paste it into the promt.
+    Alternatively, assuming your session cookie is YOURSESSIONCOOKIE, you can circumvent the login prompt by setting the username to "cookies:YOURSESSIONCOOKIE".
     **If you have any Idea how to improve this process, feel free to contribute or raise an issue**.
 4. Open AirLatex in Vim with `:AirLatex`
 Feel free to map AirLatex to a binding of your liking, e.g.:
@@ -77,16 +77,17 @@ Variable | Possible Values | Description
 `g:AirLatexLogLevel` | `NOTSET` (default), `DEBUG_GUI`, `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` | Verbosity of logging.
 `g:AirLatexLogFile` | `AirLatex.log` (default)  | Log file name. (The file appears in the folder where vim has been started, but only if the log level is greater than `NOTSET`.)
 `g:AirLatexWebsocketTimeout` | `10` (default)  | Number of seconds to wait before declaring the connection as *stale*. This may happen if the server does not answer a request by AirLatex. Setting to `"none"` disables this feature. However, it can be the case that you will not notice when something is wrong with the connection.
+`g:AirLatexBuftype` | `NOFILE` (default), `NORMAL` | Choose the buffer type between `NORMAL`, which allows writing the buffer to a local file, or `NOFILE`, which does not associate the buffer to a file.
 
 
 Troubleshooting
 ===============
-**If you find a bug.**  
+**If you find a bug.**
 Feel free to open an issue!
 To make things a bit easier for me, please use AirLatex' debug mode (`leg g:AirLatexLogLevel='DEBUG'`).
 
 
 Credits
 =======
-This plugin is a complete rework of [Vim-ShareLaTeX-Plugin](https://www.github.com/thomashn/Vim-ShareLaTeX-Plugin).  
+This plugin is a complete rework of [Vim-ShareLaTeX-Plugin](https://www.github.com/thomashn/Vim-ShareLaTeX-Plugin).
 I took all the good ideas and added even more vim love. ❥ ;)

--- a/plugin/airlatex.vim
+++ b/plugin/airlatex.vim
@@ -52,6 +52,9 @@ if !exists("g:AirLatexWebsocketTimeout")
     let g:AirLatexWebsocketTimeout=10
 endif
 
+if !exists("g:AirLatexBuftype")
+    let g:AirLatexBuftype='NOFILE'
+endif
 
 
 " vim: set sw=4 sts=4 et fdm=marker:

--- a/rplugin/python3/airlatex/documentbuffer.py
+++ b/rplugin/python3/airlatex/documentbuffer.py
@@ -36,9 +36,12 @@ class DocumentBuffer:
         DocumentBuffer.allBuffers[self.buffer] = self
 
         # Buffer Settings
+        buftype = 'nofile'
+        if self.nvim.eval("g:AirLatexBuftype") == 'NORMAL':
+            buftype = ''
         self.nvim.command("syntax on")
         self.nvim.command('setlocal noswapfile')
-        self.nvim.command('setlocal buftype=nofile')
+        self.nvim.command('setlocal buftype='+buftype)
         self.nvim.command("set filetype="+self.getExt())
 
         # ??? Returning normal function to these buttons

--- a/rplugin/python3/airlatex/documentbuffer.py
+++ b/rplugin/python3/airlatex/documentbuffer.py
@@ -19,6 +19,7 @@ class DocumentBuffer:
         self.initDocumentBuffer()
         self.buffer_mutex = RLock()
         self.saved_buffer = None
+        self.locally_saved = False
 
     def getName(self):
         return "/".join([p["name"] for p in self.path])
@@ -36,8 +37,9 @@ class DocumentBuffer:
         DocumentBuffer.allBuffers[self.buffer] = self
 
         # Buffer Settings
+        normal_buftype = self.nvim.eval("g:AirLatexBuftype") == 'NORMAL'
         buftype = 'nofile'
-        if self.nvim.eval("g:AirLatexBuftype") == 'NORMAL':
+        if normal_buftype:
             buftype = ''
         self.nvim.command("syntax on")
         self.nvim.command('setlocal noswapfile')
@@ -54,6 +56,8 @@ class DocumentBuffer:
         self.nvim.command("au CursorMoved <buffer> call AirLatex_WriteBuffer()")
         self.nvim.command("au CursorMovedI <buffer> call AirLatex_WriteBuffer()")
         self.nvim.command("command! -buffer -nargs=0 W call AirLatex_WriteBuffer()")
+        if normal_buftype:
+            self.nvim.command("au BufWritePre <buffer> call AirLatex_WriteLocalBufferPre()")
 
     def write(self, lines):
         self.log.debug("writing to buffer")


### PR DESCRIPTION
Necessary for building pdfs locally. The feature is added as an opt-in
setting. The added variable 'g:AirLatexBuftype' has default value 'NOFILE'
which has the usual behaviour (sets 'buftype' to 'nofile'). The value
'NORMAL' creates a normal buffer (sets 'buftype' to '') which allows for
local saving of the files. Any other value will not be accepted and will
have the same effect as the default.