### PR TITLE
Skipping certification validation in HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Variable | Possible Values | Description
 `g:AirLatexLogLevel` | `NOTSET` (default), `DEBUG_GUI`, `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` | Verbosity of logging.
 `g:AirLatexLogFile` | `AirLatex.log` (default)  | Log file name. (The file appears in the folder where vim has been started, but only if the log level is greater than `NOTSET`.)
 `g:AirLatexWebsocketTimeout` | `10` (default)  | Number of seconds to wait before declaring the connection as *stale*. This may happen if the server does not answer a request by AirLatex. Setting to `"none"` disables this feature. However, it can be the case that you will not notice when something is wrong with the connection.
+`g:AirLatex_insecure` | `0` (default, off), `1` (on) | Allow insecure connection. For example, if the server is self hosted and/or the certificate is self-signed
 
 
 Troubleshooting

--- a/rplugin/python3/airlatex/project_handler.py
+++ b/rplugin/python3/airlatex/project_handler.py
@@ -25,7 +25,7 @@ codere = re.compile(r"(\d):(?:(\d+)(\+?))?:(?::(?:(\d+)(\+?))?(.*))?")
 
 class AirLatexProject:
 
-    def __init__(self, url, project, used_id, sidebar, cookie=None, wait_for=15):
+    def __init__(self, url, project, used_id, sidebar, cookie=None, wait_for=15, validate_cert=True):
         project["handler"] = self
 
         self.sidebar = sidebar
@@ -34,6 +34,7 @@ class AirLatexProject:
         self.project = project
         self.url = url
         self.wait_for = wait_for if str(wait_for).isnumeric() else None
+        self.validate_cert = validate_cert
         self.cookie = cookie
         self.url_base = url.split("/")[2]
         self.command_counter = count(1)
@@ -236,7 +237,7 @@ class AirLatexProject:
             await self.sidebarMsg("Connecting Websocket.")
             self.project["connected"] = True
             self.log.debug("Initializing websocket connection to "+self.url)
-            request = HTTPRequest(self.url, headers={'Cookie': self.cookie})
+            request = HTTPRequest(self.url, headers={'Cookie': self.cookie}, validate_cert=self.validate_cert)
             self.ws = await websocket_connect(request)
         except Exception as e:
             await self.sidebarMsg("Connection Error: "+str(e))

--- a/rplugin/python3/airlatex/session.py
+++ b/rplugin/python3/airlatex/session.py
@@ -35,6 +35,7 @@ class AirLatexSession:
         self.url = ("https://" if https else "http://") + domain
         self.authenticated = False
         self.httpHandler = requests.Session()
+        self.httpHandler.verify=False if self.nvim.eval("g:AirLatex_insecure") == 1 else True
         self.projectList = []
         self.log = getLogger("AirLatex")
 
@@ -214,7 +215,7 @@ class AirLatexSession:
         # start connection
         anim_status.cancel()
         cookie_str = "; ".join(name + "=" + value for name, value in self.httpHandler.cookies.get_dict().items())
-        airlatexproject = AirLatexProject(await self._getWebSocketURL(), project, self.user_id, self.sidebar, cookie=cookie_str, wait_for=self.wait_for)
+        airlatexproject = AirLatexProject(await self._getWebSocketURL(), project, self.user_id, self.sidebar, cookie=cookie_str, wait_for=self.wait_for, validate_cert=self.httpHandler.verify)
         create_task(airlatexproject.start())
 
 


### PR DESCRIPTION
I have added the feature for skipping the certificate validation during https connection. This feature is useful if the server is self-hosted and/or the certificate is self signed (or signed by an not trusted CA).

Thanks to general settings `AirLatex_insecure` it is possible to perform insecure connection.